### PR TITLE
fix: #10 - Lints are doubled in dart

### DIFF
--- a/lua/plugins/config/flutter/flutterTools.lua
+++ b/lua/plugins/config/flutter/flutterTools.lua
@@ -1,4 +1,3 @@
-
 return {
   "akinsho/flutter-tools.nvim",
   dependencies = {

--- a/lua/plugins/config/lspConfig.lua
+++ b/lua/plugins/config/lspConfig.lua
@@ -7,12 +7,6 @@ return {
     local glsp = require "configs.lspconfig"
 
     local servers = {
-      dartls = {
-        settings = {
-          -- TODO does this work?
-          lineLength = 120,
-        },
-      },
       bashls = {
         on_attach = function(client, bufnr)
           local filename = vim.api.nvim_buf_get_name(bufnr)


### PR DESCRIPTION
Remove dartls server from lspConfig as it is already run in flutter tools
This closes #10 

This pull request includes changes to the configuration files for Flutter tools and LSP servers. The most important changes involve the removal of specific Dart language server settings and the addition of a new dependency for Flutter tools.

Configuration changes:

* [`lua/plugins/config/flutter/flutterTools.lua`](diffhunk://#diff-a1993be83f450d2a268401497a63816deab8f7b91c4a89236a12d4a41dbfd9ecL1): Added a new dependency for `akinsho/flutter-tools.nvim`.

LSP server configuration changes:

* [`lua/plugins/config/lspConfig.lua`](diffhunk://#diff-d3882ffe6b71bcbf391522f313a755180e7144bb06cc7328b7d209ec2dc76845L10-L15): Removed the Dart language server (`dartls`) settings, including the line length configuration.